### PR TITLE
Add Docker environment checks in various API server client scripts

### DIFF
--- a/admin-tools/misc/getCruiseId.py
+++ b/admin-tools/misc/getCruiseId.py
@@ -28,7 +28,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(
 
 from python_sealog.settings import apiServerURL, cruisesAPIPath, headers
 
-# FIXME: Override apiServerURL because we're outside of Docker
+# FIXME: Override apiServerURL because we're outside of Docker ("fix" in progress)
 apiServerURL = "https://localhost/sealog/server"
 
 
@@ -38,6 +38,11 @@ if __name__ == '__main__':
   parser.add_argument('cruise_id', help='cruise number (i.e. AT4201)')
 
   args = parser.parse_args()
+
+  # If the script is being run outside the container, use HTTP instead of HTTPS to contact API server.
+  if not os.path.exists('/.dockerenv'):
+    print("Outside Docker container environment, using HTTP API server URL.")
+    apiServerURL = "http://localhost/sealog/server"
 
   r = requests.get(f'{apiServerURL}/{cruisesAPIPath}', headers=headers)
 


### PR DESCRIPTION
Hi, everyone. I found [some ways](https://www.tutorialspoint.com/how-to-determine-if-a-process-runs-inside-lxc-docker) for a script to check if it's running inside a Docker container. I've implemented one of the methods in admin-tools/misc/getCruiseId.py. If you're satisfied with that approach, I'll apply it to a couple of other scripts that have the same need (admin-tools/misc/getLoweringId.py and admin-tools/sealog_postdive.sh). 