### PR TITLE
Reconcile operations with version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+python_sealog/settings.py

--- a/import-tools/convert_framegrab_copy_script.py
+++ b/import-tools/convert_framegrab_copy_script.py
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 import re
+import socket
 import sys
 import copy
 
@@ -41,7 +42,7 @@ logger.addHandler(ch)
 
 
 # FIXME: This is really hacky
-if "harmonyhill" in os.getenv("HOSTNAME", ""):
+if "harmonyhill" in socket.gethostname():
     imageBaseDir = {
         "Jason": "/home/sealog/sealog-files-jason/images",
         "Alvin": "/home/sealog/sealog-files-alvin/images",

--- a/import-tools/import_cruise_record_into_sealog.sh
+++ b/import-tools/import_cruise_record_into_sealog.sh
@@ -78,7 +78,10 @@ if [ -f /opt/sealog/dc ]; then
     DC_COMMAND="/opt/sealog/dc $VEHICLE"
 fi
 
-sudo ${DC_COMMAND} exec mongo \
+# Determine if we need sudo to interact with docker
+DC_SUDO=$(docker version >/dev/null 2>&1 || echo "sudo")
+
+${DC_SUDO} ${DC_COMMAND} exec mongo \
   mongoimport \
     --db sealogDB \
     --collection cruises \

--- a/import-tools/import_lowering_into_sealog.sh
+++ b/import-tools/import_lowering_into_sealog.sh
@@ -116,9 +116,12 @@ for LOWERING in $LOWERINGS; do
     DC_COMMAND="/opt/sealog/dc $VEHICLE"
   fi
 
+  # Determine if we need ${DC_SUDO} to interact with docker
+  DC_SUDO=$(docker version >/dev/null 2>&1 || echo "sudo")
+
   echo "Importing lowering record..."
   lowering_filename="${CRUISE}/${LOWERING}/modifiedForImport/${LOWERING}_loweringRecord_mod.json"
-  sudo ${DC_COMMAND} exec mongo \
+  ${DC_SUDO} ${DC_COMMAND} exec mongo \
     mongoimport \
       --db sealogDB \
       --collection lowerings \
@@ -128,7 +131,7 @@ for LOWERING in $LOWERINGS; do
 
   echo "Importing lowering events"
   event_filename="${CRUISE}/${LOWERING}/modifiedForImport/${LOWERING}_eventOnlyExport_mod.json"
-  sudo ${DC_COMMAND} exec mongo \
+  ${DC_SUDO} ${DC_COMMAND} exec mongo \
     mongoimport \
       --db sealogDB \
       --collection events \
@@ -139,7 +142,7 @@ for LOWERING in $LOWERINGS; do
 
   echo "Importing lowering aux data"
   auxdata_filename="${CRUISE}/${LOWERING}/modifiedForImport/${LOWERING}_auxDataExport_mod.json"
-  sudo ${DC_COMMAND} exec mongo \
+  ${DC_SUDO} ${DC_COMMAND} exec mongo \
     mongoimport \
       --db sealogDB \
       --collection event_aux_data \

--- a/sealog-queryLowering.py
+++ b/sealog-queryLowering.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+'''
+This script provides a command line interface for querying for lowering and
+cruise IDs given a timestamp.
+'''
+
+import argparse
+import datetime
+import logging
+import sys
+
+import python_sealog.settings
+import time
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__file__)
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--url', default=python_sealog.settings.apiServerURL)
+parser.add_argument('--get', dest='mode',
+                    choices=('cruise', 'lowering', 'dive'), default='lowering')
+parser.add_argument('--time', default='now')
+args = parser.parse_args()
+
+
+# Override python_sealog's server URL, then do late import of API
+python_sealog.settings.apiServerURL = args.url
+
+import python_sealog.cruises
+import python_sealog.lowerings
+
+
+# Handle synonymous dive/lowering
+if args.mode == 'dive':
+    args.mode = 'lowering'
+
+# Parse the timestamp
+fixzulu = lambda t: t.replace('Z', '+00:00')
+if args.time == 'now':
+    # Ridiculously, datetime.datetime.utcnow() is not timezone aware!
+    args.time = datetime.datetime.now(datetime.timezone.utc)
+else:
+    args.time = datetime.datetime.fromisoformat(fixzulu(args.time))
+
+# Find the first lowering that matches our timestamp
+for lowering in python_sealog.lowerings.getLowerings() or []:
+    start = datetime.datetime.fromisoformat(fixzulu(lowering['start_ts']))
+    stop  = datetime.datetime.fromisoformat(fixzulu(lowering['stop_ts']))
+    if start <= args.time < stop:
+        break
+else:
+    print('null')
+    sys.exit(1)
+
+if args.mode == 'lowering':
+    print(lowering['lowering_id'])
+    sys.exit(0)
+
+# Look up the cruise for this lowering
+assert args.mode == 'cruise'
+cruise = python_sealog.cruises.getCruiseByLowering(lowering['id'])
+
+if cruise is None:
+    print('null')
+    sys.exit(1)
+
+print(cruise['cruise_id'])


### PR DESCRIPTION
Some cleanup necessary for reconciling version control with what's in use in the field. Changes include:

- Misc patches
- Utility for querying IDs
- Hostname and sudo use fixes
- Modifying import to only query vehicle ID once
- Adding .gitignore